### PR TITLE
Feature: Add Sawagger API documentation using code annotation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'unicorn-worker-killer'
 
 # Templating
 gem 'haml', '~> 5.2.2'
-gem 'redcarpet'
 gem 'rack-contrib'
 
 # NCBO gems (can be from a local dev path or from rubygems/git)

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'unicorn-worker-killer'
 
 # Templating
 gem 'haml', '~> 5.2.2'
+gem 'redcarpet'
 gem 'rack-contrib'
 
 # NCBO gems (can be from a local dev path or from rubygems/git)

--- a/controllers/application_controller.rb
+++ b/controllers/application_controller.rb
@@ -1,5 +1,8 @@
 # This is the base class for controllers in the application.
 # Code in the before or after blocks will run on every request
+require_relative '../helpers/swagger_ui_helper'
+require_relative '../helpers/openapi_helper'
+
 class ApplicationController
   include Sinatra::Delegator
   extend Sinatra::Delegator
@@ -11,5 +14,67 @@ class ApplicationController
   # Run after route
   after {
   }
+
+  register Sinatra::OpenAPIHelper
+
+  configure do
+    set :app_name, 'Pet Store API'
+    set :api_version, '1.0.0'
+    set :api_description, 'A sample Pet Store API'
+    set :base_url, 'http://localhost:4567'
+
+    # TODO: add them automatically
+    set :api_schemas, {
+      Pet: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          name: { type: 'string' },
+          species: { type: 'string' }
+        }
+      },
+      NewPet: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          species: { type: 'string' }
+        },
+        required: ['name', 'species']
+      }
+    }
+  end
+
+  doc('List all pets') do
+    parameter('page', type: 'integer', description: 'Page number')
+    parameter('pagesize', type: 'integer', description: 'Number of items per page')
+    response(200, '', content({ type: 'array', items: { '$ref' => '#/components/schemas/Pet' } }))
+    response(404, '')
+  end
+  get '/pets' do
+    content_type :json
+    [].to_json
+  end
+
+  doc('Create a pet') do
+    body_parameter('pet', schema: { '$ref' => '#/components/schemas/NewPet' })
+    response(201, 'Pet created', content({ '$ref' => '#/components/schemas/Pet' }))
+    response(400, 'Invalid input')
+  end
+  post '/pets' do
+    content_type :json
+    request.body.rewind
+    data = JSON.parse(request.body.read)
+    data.to_json
+  end
+
+  doc('Delete a pet') do
+    path_parameter('id', description: 'Pet ID')
+    response(200, 'Pet deleted')
+    response(400, 'Invalid ID')
+  end
+  delete '/pets/:id' do
+    content_type :json
+    'removed'.to_json
+  end
 
 end

--- a/controllers/artefacts.rb
+++ b/controllers/artefacts.rb
@@ -4,11 +4,9 @@ class ArtefactsController < ApplicationController
         # Get all Semantic Artefacts
         get do
             check_last_modified_collection(LinkedData::Models::SemanticArtefact)
-            options = {
-                also_include_views: params['also_include_views'] ||= false,
-                includes: LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
-            }
-            artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(options)
+            attributes, page, pagesize, _, _ = settings_params(LinkedData::Models::SemanticArtefact)
+            pagesize = 20 if params["pagesize"].nil?
+            artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(attributes, page, pagesize)
             reply artefacts
         end
 

--- a/controllers/documentation_controller.rb
+++ b/controllers/documentation_controller.rb
@@ -1,0 +1,33 @@
+class DocumentationController < ApplicationController
+  get '/api-docs' do
+    content_type 'text/html'
+    <<-HTML
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <title>API Documentation</title>
+            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui.min.css" />
+          </head>
+          <body>
+            <div id="swagger-ui"></div>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui-bundle.min.js"></script>
+            <script>
+              window.onload = () => {
+                window.ui = SwaggerUIBundle({
+                  url: '/openapi.json',
+                  dom_id: '#swagger-ui',
+                });
+              };
+            </script>
+          </body>
+          </html>
+        HTML
+  end
+
+  # Serve OpenAPI JSON
+  get '/openapi.json' do
+    content_type :json
+    generate_openapi_json.to_json
+  end
+end

--- a/helpers/openapi_helper.rb
+++ b/helpers/openapi_helper.rb
@@ -1,0 +1,70 @@
+require 'sinatra/base'
+require 'ostruct'
+module Sinatra
+  module OpenAPIHelper
+    class OpenAPIDoc
+      Parameter = Struct.new(:name, :in, :required, :type, :description, :schema, keyword_init: true)
+      Response = Struct.new(:description, :content, keyword_init: true)
+
+      def initialize(summary)
+        @summary = summary
+        @parameters = []
+        @responses = {}
+      end
+
+      def to_hash
+        {
+          summary: @summary,
+          parameters: @parameters,
+          responses: @responses
+        }
+      end
+
+      def content(schema, content_type = 'application/json-ld')
+        { content_type => { schema: schema } }
+      end
+
+      def response(status, description = nil, content = nil)
+        @responses[status] = Response.new(description: description, content: content)
+      end
+
+      def parameter(name, in_: 'query', required: false, type: 'string', description: nil, schema: nil)
+        @parameters << Parameter.new(name: name, in: in_, required: required, type: type, description: description, schema: schema)
+      end
+
+      def path_parameter(name, required: true, type: 'string', description: nil, schema: nil)
+        parameter(name, in_: 'path', required: required, type: type, description: description, schema: schema)
+      end
+
+      def body_parameter(name, required: true, type: 'object', description: nil, schema: nil)
+        parameter(name, in_: 'body', required: required, type: type, description: description, schema: schema)
+      end
+    end
+
+    def doc(summary, &block)
+      doc = OpenAPIDoc.new(summary)
+      doc.instance_eval(&block)
+      @pending_api_doc = doc.to_hash
+    end
+
+    def self.registered(app)
+      app.before do
+        # Clear any pending documentation that wasn't used
+        @pending_api_doc = nil
+      end
+    end
+
+    def route(verb, path, opts = {}, &block)
+      if @pending_api_doc
+        @api_docs ||= {}
+        @api_docs[path.first] ||= {}
+        @api_docs[path.first][verb.downcase] = @pending_api_doc
+        @pending_api_doc = nil
+      end
+      super(verb, path, opts, &block)
+    end
+  end
+end
+
+
+

--- a/helpers/swagger_ui_helper.rb
+++ b/helpers/swagger_ui_helper.rb
@@ -1,0 +1,39 @@
+require 'json'
+require 'sinatra/base'
+
+
+module Sinatra
+  module SwaggerUI
+    def generate_openapi_json
+      {
+        openapi: '3.0.0',
+        info: {
+          title: settings.app_name || 'API Documentation',
+          version: settings.api_version || '1.0.0',
+          description: settings.api_description || 'API Documentation'
+        },
+        servers: [
+          {
+            url: settings.base_url || '/',
+            description: 'API Server'
+          }
+        ],
+        paths: generate_paths,
+        components: {
+          schemas: settings.respond_to?(:api_schemas) ? settings.api_schemas : {}
+        }
+      }
+    end
+
+    def generate_paths
+      paths = {}
+      api_docs = settings.instance_variable_get(:@api_docs)
+      api_docs.each do |path, methods|
+        paths[path] = methods.transform_keys(&:to_s)
+      end
+      paths
+    end
+  end
+end
+
+helpers Sinatra::SwaggerUI


### PR DESCRIPTION
### Context
This is a first iteration on having swagger UI for the ontportal API, that can be generated automatically or through code annotation.
So that if we write in the code
```ruby 
 doc('List all pets') do
    parameter('page', type: 'integer', description: 'Page number')
    parameter('pagesize', type: 'integer', description: 'Number of items per page')
    response(200, '', content({ type: 'array', items: { '$ref' => '#/components/schemas/Pet' } }))
    response(404, '')
  end
  get '/pets' do
    content_type :json
    [].to_json
  end
```

it will generate automatically the endpoint `/api-docs`
![image](https://github.com/user-attachments/assets/adf9d6ac-59bb-473b-8304-0b736f2c3911)

### Changes
* Add a DSL to document Sinatra endpoints using openapi (https://github.com/biodivportal/ontologies_api/pull/7/commits/3ba664052b30e208173f287f96c21031495551ce)
* Add two endpoints to show swagger ui or openapi.json (https://github.com/biodivportal/ontologies_api/pull/7/commits/8e87c80ffcb4fe8e654162ef5e10a6826bdd0ccd)
* Use the new DSL an example API for now (https://github.com/biodivportal/ontologies_api/pull/7/commits/55d738f94ed544cccb11a2740983f976f5b522b4)